### PR TITLE
Fixed windows path error + shape mismatch error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # Chrome-history-plot
-It is a python script that plots the top visited sites through chrome browser in a bar-graph(using pylab)
+It is a python script that plots the top visited sites through chrome browser in a bar-graph (using <i>pylab</i>).
 
--- Only for windows as of now -- 
+Now available for:
+1. Windows
+2. Linux
+3. Mac
+
+<b>Caution</b>: The program doesn't run while chrome is running (throws database lock error).

--- a/main.py
+++ b/main.py
@@ -44,13 +44,21 @@ for url, count in results:
 
 sites_count_sorted = OrderedDict(sorted(sites_count.items(), key=operator.itemgetter(1), reverse=True))
 
-index = [1,2,3, 4, 5, 6, 7, 8, 9]	# len(index) = 10(old) --> 9(new), else throwing shape mismatch error because len(index) != len(count).
+index = []	# Don't hardcode the indices. Append indices later depending on count length(max 10).
 
-count = list(sites_count_sorted.values())[:10]	# len(count) = 9
+count = list(sites_count_sorted.values())[:10]	# Whatever the no. of sites are, limit it to <= 10.
+
+# Making sure len(count) = len(index)
+l = len(count)
+for i in range (0, l):
+	index.append(i)
 
 LABELS = list(sites_count_sorted.items())[:10]
 
-
 plt.bar(index, count, align='center')	# length of index & count list must be same, otherwise will throw shape mismatch error.
-plt.xticks(index, LABELS)
+plt.xticks(index, LABELS, rotation = 14)	# default rotation = 0
 plt.show()
+
+# The program doesn't run while chrome is running (throws database lock error).
+# index & count length automated.
+# The labels appear congested, so rotation = 14 is applied.

--- a/main.py
+++ b/main.py
@@ -12,10 +12,14 @@ def parse(url):
 		domain = sublevel_split[0].replace("www.", "")
 		return domain
 	except IndexError:
-		print "Error reading URL"
+		print ("Error reading URL")	# print "" syntax no longer works for python v3.x
 
+# \\ used instead of \ due to :
+# Typical error on Windows because the default user directory is C:\user\<your_user>,
+# so when you want to use this path as an string parameter into a Python function,
+# you get a Unicode error, just because the \u is a Unicode escape. Any character not numeric after this produces an error.
 
-data_path = os.path.expanduser('~')+"\AppData\Local\Google\Chrome\User Data\Default" #path to user's history database (Chrome)
+data_path = os.path.expanduser('~')+"\\AppData\\Local\\Google\\Chrome\\User Data\\Default" #path to user's history database (Chrome)
 files = os.listdir(data_path)
 
 history_db = os.path.join(data_path, 'history')
@@ -40,13 +44,13 @@ for url, count in results:
 
 sites_count_sorted = OrderedDict(sorted(sites_count.items(), key=operator.itemgetter(1), reverse=True))
 
-index = [1,2,3, 4, 5, 6, 7, 8, 9, 10]
+index = [1,2,3, 4, 5, 6, 7, 8, 9]	# len(index) = 10(old) --> 9(new), else throwing shape mismatch error because len(index) != len(count).
 
-count = list(sites_count_sorted.values())[:10]
+count = list(sites_count_sorted.values())[:10]	# len(count) = 9
 
 LABELS = list(sites_count_sorted.items())[:10]
 
 
-plt.bar(index, count, align='center')
+plt.bar(index, count, align='center')	# length of index & count list must be same, otherwise will throw shape mismatch error.
 plt.xticks(index, LABELS)
 plt.show()


### PR DESCRIPTION
Hey there,
I tested your code on my Windows platform and found out a few bugs...
1. `print ""` syntax no longer works for python v3.x
2. \\\ is used instead of \ in Windows path(data_path variable) due to Unicode escape \u
3. index list length is updated to account for shape mismatch error.

EDIT: 
- Shape mismatch error is fixed permanently. 
- The labels are more clear now.
- README is updated.

That's it!
Review the changes and merge it if satisfactory :)